### PR TITLE
Fix secret leakage into logs and process listings

### DIFF
--- a/cron/crontab.example
+++ b/cron/crontab.example
@@ -6,25 +6,29 @@ SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 TOOLKIT_DIR=/path/to/groundup-toolkit
 
+# Uses load-env.sh to export only the secrets each job needs,
+# instead of sourcing the entire .env into every process.
+# See scripts/load-env.sh for the per-job variable mappings.
+
 # Meeting reminders - every 5 minutes
 # Sends WhatsApp reminders 10-15 min before meetings
-*/5 * * * * source $TOOLKIT_DIR/.env && $TOOLKIT_DIR/skills/meeting-reminders/meeting-reminders reminders >> /var/log/meeting-reminders.log 2>&1
+*/5 * * * * $TOOLKIT_DIR/scripts/load-env.sh meeting-reminders -- $TOOLKIT_DIR/skills/meeting-reminders/meeting-reminders reminders >> /var/log/meeting-reminders.log 2>&1
 
 # Meeting bot - process recordings every 2 hours
-0 */2 * * * source $TOOLKIT_DIR/.env && $TOOLKIT_DIR/skills/meeting-bot/meeting-bot >> /var/log/meeting-bot.log 2>&1
+0 */2 * * * $TOOLKIT_DIR/scripts/load-env.sh meeting-bot -- $TOOLKIT_DIR/skills/meeting-bot/meeting-bot >> /var/log/meeting-bot.log 2>&1
 
 # Meeting auto-join - every 3 minutes
-*/3 * * * * source $TOOLKIT_DIR/.env && $TOOLKIT_DIR/skills/meeting-bot/meeting-auto-join >> /var/log/meeting-auto-join.log 2>&1
+*/3 * * * * $TOOLKIT_DIR/scripts/load-env.sh meeting-bot -- $TOOLKIT_DIR/skills/meeting-bot/meeting-auto-join >> /var/log/meeting-auto-join.log 2>&1
 
 # Email-to-deal automation - every 10 minutes
 # Scans inbox for pitch decks / deal emails and creates HubSpot deals
-*/10 * * * * source $TOOLKIT_DIR/.env && cd $TOOLKIT_DIR && $TOOLKIT_DIR/.venv/bin/python3 scripts/email-to-deal-automation.py >> /var/log/email-to-deal.log 2>&1
+*/10 * * * * $TOOLKIT_DIR/scripts/load-env.sh email-to-deal -- $TOOLKIT_DIR/.venv/bin/python3 $TOOLKIT_DIR/scripts/email-to-deal-automation.py >> /var/log/email-to-deal.log 2>&1
 
 # Health check - every 15 minutes
 */15 * * * * $TOOLKIT_DIR/scripts/health-check.sh >> /var/log/toolkit-health.log 2>&1
 
 # WhatsApp watchdog - every 5 minutes
-*/5 * * * * $TOOLKIT_DIR/scripts/whatsapp-watchdog.sh >> /var/log/whatsapp-watchdog.log 2>&1
+*/5 * * * * $TOOLKIT_DIR/scripts/load-env.sh watchdog -- $TOOLKIT_DIR/scripts/whatsapp-watchdog.sh >> /var/log/whatsapp-watchdog.log 2>&1
 
 # Scheduled tasks (Shabbat-aware) - every 2 hours
 0 */2 * * * $TOOLKIT_DIR/scripts/run-scheduled.sh >> /var/log/scheduled.log 2>&1

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Load specific environment variables from .env for a given job.
+# Usage: load-env.sh <job-name> -- <command...>
+#
+# Instead of `source .env` (which loads ALL secrets into the shell),
+# this wrapper only exports the variables each job actually needs.
+# This limits the blast radius if a process logs its environment.
+
+set -euo pipefail
+
+TOOLKIT_DIR="${TOOLKIT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+ENV_FILE="${TOOLKIT_DIR}/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: .env not found at $ENV_FILE" >&2
+    exit 1
+fi
+
+# Read .env into an associative array (without exporting everything)
+declare -A ALL_VARS
+while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"  # trim leading whitespace
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    line="${line#export }"
+    key="${line%%=*}"
+    val="${line#*=}"
+    val="${val%\"}"; val="${val#\"}"  # strip quotes
+    val="${val%\'}"; val="${val#\'}"
+    ALL_VARS["$key"]="$val"
+done < "$ENV_FILE"
+
+# Helper: export a var from ALL_VARS if it exists
+export_var() {
+    local key="$1"
+    if [[ -n "${ALL_VARS[$key]+x}" ]]; then
+        export "$key"="${ALL_VARS[$key]}"
+    fi
+}
+
+JOB="$1"
+shift
+
+# Skip the "--" separator if present
+[[ "${1:-}" == "--" ]] && shift
+
+# Export only the variables each job needs
+case "$JOB" in
+    meeting-reminders)
+        export_var GOG_KEYRING_PASSWORD
+        export_var GOG_ACCOUNT
+        export_var MATON_API_KEY
+        export_var ANTHROPIC_API_KEY
+        export_var BRAVE_SEARCH_API_KEY
+        ;;
+    meeting-bot)
+        export_var GOG_KEYRING_PASSWORD
+        export_var GOG_ACCOUNT
+        export_var ANTHROPIC_API_KEY
+        ;;
+    email-to-deal)
+        export_var GOG_KEYRING_PASSWORD
+        export_var GOG_ACCOUNT
+        export_var MATON_API_KEY
+        export_var ANTHROPIC_API_KEY
+        ;;
+    watchdog)
+        export_var ASSISTANT_WHATSAPP_PHONE
+        export_var ALERT_PHONE
+        export_var ALERT_EMAIL
+        export_var GOG_ACCOUNT
+        export_var GOG_KEYRING_PASSWORD
+        export_var TWILIO_ACCOUNT_SID
+        export_var TWILIO_API_KEY_SID
+        export_var TWILIO_API_KEY_SECRET
+        export_var TWILIO_FROM_NUMBER
+        ;;
+    *)
+        # Fallback: load all vars (same as before, for unknown jobs)
+        for key in "${!ALL_VARS[@]}"; do
+            export "$key"="${ALL_VARS[$key]}"
+        done
+        ;;
+esac
+
+# Run the command
+exec "$@"

--- a/skills/meeting-reminders/reminders.py
+++ b/skills/meeting-reminders/reminders.py
@@ -110,15 +110,18 @@ class ReminderDatabase:
 
 
 def run_gog_command(cmd):
-    """Run gog command with keyring password"""
+    """Run gog command with keyring password.
+
+    Uses shell=False with argument list to prevent secrets from appearing
+    in shell command strings (which could leak into logs or ps output).
+    """
     env = os.environ.copy()
     env['GOG_KEYRING_PASSWORD'] = os.environ.get("GOG_KEYRING_PASSWORD", "")
-    full_cmd = f'gog {cmd} --account {shlex.quote(GOG_ACCOUNT)} --json'
+    cmd_args = ['gog'] + shlex.split(cmd) + ['--account', GOG_ACCOUNT, '--json']
 
     try:
         result = subprocess.run(
-            full_cmd,
-            shell=True,
+            cmd_args,
             capture_output=True,
             text=True,
             timeout=30,


### PR DESCRIPTION
## Summary

Three targeted fixes to prevent API keys and credentials from leaking into log files, `ps` output, or shell command strings. No architectural changes — all fixes are backward-compatible and preserve existing behavior.

- **`reminders.py`**: Switch from `shell=True` + f-string to `shell=False` + argument list. Prevents command strings from appearing in exception tracebacks written to `/var/log/meeting-reminders.log`
- **`whatsapp-watchdog.sh`**: Replace `curl -u` (credentials visible in `ps aux` and logs) with `--netrc-file` using a temporary file with `0600` permissions, cleaned up immediately after use
- **`crontab.example`**: Replace blanket `source .env` with a new `load-env.sh` wrapper that exports only the specific env vars each job needs, limiting blast radius if any process logs its environment

## Files changed

| File | Change |
|------|--------|
| `skills/meeting-reminders/reminders.py` | `shell=True` → `shell=False` with arg list |
| `scripts/whatsapp-watchdog.sh` | `curl -u` → `--netrc-file` with temp file |
| `scripts/load-env.sh` | **New** — per-job env loader with scoped variable exports |
| `cron/crontab.example` | `source .env` → `load-env.sh <job> -- <cmd>` |

## Why this matters

Log files (`/var/log/meeting-reminders.log`, `/var/log/whatsapp-watchdog.log`, etc.) typically have broader permissions than `.env`, are rotated to remote storage, and can be captured by monitoring tools. Secrets that leak into logs propagate far beyond the server.

Closes #2

## Test plan

- [ ] Verify `meeting-reminders` still fetches calendar events and sends WhatsApp messages
- [ ] Verify `whatsapp-watchdog.sh` Twilio call alert still fires on WhatsApp failure
- [ ] Verify `load-env.sh` correctly exports scoped vars for each job name
- [ ] Verify cron jobs still run on schedule with the `load-env.sh` wrapper
- [ ] Confirm no secrets appear in log files after running each job