### PR TITLE
Remove anthropic-dangerous-direct-browser-access API header

### DIFF
--- a/skills/deck-analyzer/analyzer.py
+++ b/skills/deck-analyzer/analyzer.py
@@ -96,8 +96,7 @@ Pitch deck content:
         headers = {
             'x-api-key': ANTHROPIC_API_KEY,
             'anthropic-version': '2023-06-01',
-            'content-type': 'application/json',
-            'anthropic-dangerous-direct-browser-access': 'true'
+            'content-type': 'application/json'
         }
 
         payload = {


### PR DESCRIPTION
## Summary
- Fix **HIGH** severity issue: unnecessary `anthropic-dangerous-direct-browser-access` header in deck-analyzer API calls

## Changes
- Remove the `anthropic-dangerous-direct-browser-access: true` header from Claude API requests in `skills/deck-analyzer/analyzer.py`

## Why This Is Dangerous
This header is intended **only** for client-side browser apps that must call the Anthropic API directly from the browser. It relaxes certain API safety checks.

The deck analyzer is a **server-side script** that processes untrusted pitch deck content from external senders. Full API safety checks are important here to help mitigate prompt injection attacks where malicious content is embedded in pitch decks.

## Test plan
- [ ] Verify deck analysis still works correctly without the header
- [ ] Verify Claude API calls return expected structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)