### PR TITLE
Remove blanket .pdf URL pattern from deck link extraction

### DIFF
--- a/skills/deal-analyzer/analyzer.py
+++ b/skills/deal-analyzer/analyzer.py
@@ -255,7 +255,9 @@ DOCSEND_PATTERN = re.compile(r'https://docsend\.com/view/[a-zA-Z0-9]+')
 GDOCS_PATTERN = re.compile(r'https://docs\.google\.com/[^\s<>"]+')
 GDRIVE_PATTERN = re.compile(r'https://drive\.google\.com/[^\s<>"]+')
 DROPBOX_PATTERN = re.compile(r'https://www\.dropbox\.com/[^\s<>"]+')
-PDF_PATTERN = re.compile(r'https://[^\s<>"]*\.pdf')
+# Only match PDF links on known allowed domains (not arbitrary domains)
+PAPERMARK_PATTERN = re.compile(r'https://(?:www\.)?papermark\.com/view/[^\s<>"]+')
+PITCH_PATTERN = re.compile(r'https://(?:www\.)?pitch\.com/[^\s<>"]+')
 
 # Allowed URL domains for deck fetching (SSRF protection)
 ALLOWED_DECK_DOMAINS = {
@@ -296,7 +298,7 @@ def is_safe_url(url):
 
 def extract_deck_links(text):
     links = []
-    for pattern in [DOCSEND_PATTERN, GDOCS_PATTERN, GDRIVE_PATTERN, DROPBOX_PATTERN, PDF_PATTERN]:
+    for pattern in [DOCSEND_PATTERN, GDOCS_PATTERN, GDRIVE_PATTERN, DROPBOX_PATTERN, PAPERMARK_PATTERN, PITCH_PATTERN]:
         links.extend(pattern.findall(text))
     return list(dict.fromkeys(links))
 


### PR DESCRIPTION
## Summary
- Fix **MEDIUM** severity SSRF defense-in-depth issue in `deck-analyzer/analyzer.py`
- The `PDF_PATTERN` regex (`https://[^\s<>"]*\.pdf`) matched any URL ending in `.pdf` from any domain

## Changes
- Replace blanket `PDF_PATTERN` with specific `PAPERMARK_PATTERN` and `PITCH_PATTERN` for known deck hosting domains
- Update both `extract_deck_links()` functions to use domain-specific patterns only

## Why This Matters
While `is_safe_url()` provides a second layer of defense, the link extraction pattern should also be restrictive (defense in depth). An attacker could embed a link like `https://evil-internal.com/data.pdf` in an email, and it would be:
1. Extracted as a "deck link" by the blanket `.pdf` pattern
2. Passed to `fetch_deck_content()` which calls `is_safe_url()`

If `is_safe_url()` ever has a bypass (see companion PR for SSRF fixes), the extraction layer is the only defense.

## Test plan
- [ ] Verify deck links from DocSend, Google Docs, Google Drive, Dropbox are still extracted
- [ ] Verify Papermark and Pitch.com links are now extracted (newly added patterns)
- [ ] Verify arbitrary `.pdf` URLs from unknown domains are no longer extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)